### PR TITLE
Fixing type of stationStatus() and stationInfo()

### DIFF
--- a/src/gbfs.ts
+++ b/src/gbfs.ts
@@ -25,14 +25,14 @@ class GbfsClient {
       });
   }
 
-  public stationInfo(stationId: string): Promise<StationInfo[]>;
-  public stationInfo(): Promise<StationInfo>;
+  public stationInfo(stationId: string): Promise<StationInfo>;
+  public stationInfo(): Promise<StationInfo[]>;
   public stationInfo(stationId?: string): Promise<StationInfo | StationInfo[]> {
     return this.stations(this.urls.stationInfo, stationId);
   }
 
-  public stationStatus(stationId: string): Promise<StationStatus[]>;
-  public stationStatus(): Promise<StationStatus>;
+  public stationStatus(stationId: string): Promise<StationStatus>;
+  public stationStatus(): Promise<StationStatus[]>;
   public stationStatus(stationId?: string): Promise<StationStatus | StationStatus[]> {
     return this.stations(this.urls.stationStatus, stationId);
   }


### PR DESCRIPTION
**Description :** 

`stationStatus` and `stationInfo` have 2 overloading types.

Normaly the `stationStatus` should return an array, and the `stationStatus(id)`  a single entity.

This PR fix this type issue