### PR TITLE
Fix Missing HTTP Header

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1,18 +1,29 @@
 import * as http from 'http';
 import * as https from 'https';
+import { URL } from 'url';
 
 // Promisified http(s) get
 export function get(url: string): Promise<string> {
+  const parsedUrl = new URL(url);
   return new Promise<string>((resolve, reject) => {
 
     const getFn = url.startsWith('https') ? https.get : http.get;
 
-    getFn(url, (res) => {
+    getFn({
+      headers: {
+        'User-Agent': 'request',
+      },
+      hostname: parsedUrl.hostname,
+      method: 'GET',
+      path: parsedUrl.pathname,
+      port: parsedUrl.port,
+
+    }, (res) => {
       if (!res.statusCode || res.statusCode < 200 || res.statusCode > 299) {
         reject(new Error(`Failure: status code ${res.statusCode}`));
       }
 
-      const body: Array<string|Buffer> = [];
+      const body: Array<string | Buffer> = [];
       res.on('data', (chunk) => body.push(chunk));
       res.on('end', () => resolve(body.join('')));
 

--- a/test/test.js
+++ b/test/test.js
@@ -32,8 +32,16 @@ describe('httpClient', function () {
           assert.equal(err.message, 'Failure: status code 301');
         })
     })
-  })
-})
+    it('should resolved with Bixi url', function () {
+      return httpClient.get('https://api-core.bixi.com/gbfs/gbfs.json')
+        .then(function (data) {
+          assert.equal(typeof data, 'string');
+          const bixiData = JSON.parse(data);
+          assert.equal(typeof bixiData, 'object')
+        });
+    });
+  });
+});
 
 describe('gbfsClient', function () {
   describe('#system()', function () {


### PR DESCRIPTION
Finding a bug on integration tests.

Gbfs servers tends to returns a 403 error if we don't pass header.

I fix the issue by passing an entire request object to the `https | http .get` method to avoid get Forbidden error.

The url passed to the http is now parsed properly and handle by node `url` core module.

- [x]  Linter Passed
- [x] Tests Passed